### PR TITLE
Print template names rather than objects

### DIFF
--- a/flask_testing/utils.py
+++ b/flask_testing/utils.py
@@ -244,9 +244,9 @@ class TestCase(unittest.TestCase):
             if getattr(template, tmpl_name_attribute) == name:
                 return True
 
-            used_templates.append(template)
+            used_templates.append(template.name)
 
-        raise AssertionError("Template %s not used. Templates were used: %s" % (name, ' '.join(repr(used_templates))))
+        raise AssertionError("Template %s not used. Templates used: %r" % (name, used_templates))
 
     assert_template_used = assertTemplateUsed
 


### PR DESCRIPTION
Use `template.name` rather than `repr(template)`. Jinja2 templates don't have names if they're created from strings, but in that case `assertTemplateUsed()` is not appropriate.
